### PR TITLE
Add .gitattributes to enforce LF for shell/Docker/Unix files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,39 @@
+# Default: let Git decide text vs. binary and normalize line endings on commit.
+# Working-tree endings follow the platform / core.autocrlf for these files.
+* text=auto
+
+# --- Files that must always be LF (Unix/Linux tooling breaks on CRLF) ---
+
+# Shell scripts
+*.sh   text eol=lf
+*.bash text eol=lf
+*.zsh  text eol=lf
+
+# Docker
+Dockerfile      text eol=lf
+*.Dockerfile    text eol=lf
+Dockerfile.*    text eol=lf
+.dockerignore   text eol=lf
+
+# Other Unix/Linux config & dotfiles run inside containers / *nix shells
+.bashrc      text eol=lf
+.bash_profile text eol=lf
+.profile     text eol=lf
+.editorconfig text eol=lf
+*.conf       text eol=lf
+
+# --- Force CRLF for Windows-only scripts ---
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# --- Treat known binaries as binary (no EOL conversion / diff) ---
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.svg  text
+*.jks  binary
+*.keystore binary
+*.plist text


### PR DESCRIPTION
## Why

On Windows checkouts `core.autocrlf=true` rewrites LF → CRLF. For shell scripts this corrupts the shebang (`#!/bin/bash` becomes `#!/bin/bash\r`), so running them under WSL/Linux fails with:

```
-bash: ./build-mobile.sh: cannot execute: required file not found
```

`chmod +x` doesn't help — the kernel can't find the mangled interpreter path.

## What

Adds a `.gitattributes` that:

- `* text=auto` — keeps normal line-ending normalization for everything else (platform-native in the working tree)
- Pins **LF** (`eol=lf`) for Unix-run files: `*.sh`, `*.bash`, `*.zsh`, `Dockerfile`, `*.Dockerfile`, `Dockerfile.*`, `.dockerignore`, and common Unix dotfiles/`*.conf`
- Pins **CRLF** (`eol=crlf`) for Windows-only scripts: `*.bat`, `*.cmd`, `*.ps1`
- Marks known binaries (`*.png`, `*.jks`, etc.) as `binary` to skip EOL conversion

This guarantees shell/Docker files stay LF on every checkout regardless of each developer's `core.autocrlf` setting.

## Notes

- Repo blobs were already stored as LF, so `git add --renormalize .` produced no content changes — only `.gitattributes` is added. The fix is preventative: future Windows checkouts will no longer re-introduce CRLF into these files.
- After merging, run `git rm --cached -r . && git reset --hard` (or just re-checkout) to refresh any locally-CRLF working copies to LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)