### PR TITLE
Improve build-mobile.sh: arg support, guards, drop broken push, PACKAGE_TYPE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,16 @@ ARG USER
 ARG ENV_NAME
 ARG PACKAGE_ID
 ARG VERSION
+ARG PACKAGE_TYPE
 
 # If arguments not specified then set a value
 ENV USER=${USER:-ionic}
 ENV ENV_NAME=${ENV_NAME:-dev}
 ENV PACKAGE_ID=${PACKAGE_ID:-"com.example.com"}
 ENV VERSION=${VERSION:-"MISSING"}
+# Android artifact type: "bundle" (.aab for Google Play) or "apk" (installable on a device).
+# Overrides the packageType in build.json so it can be chosen per build.
+ENV PACKAGE_TYPE=${PACKAGE_TYPE:-bundle}
 
 RUN echo "------------------------------------------"&& \
     echo "| BUILDING MOBILE APPLICATION             "&& \
@@ -72,7 +76,7 @@ ENV BUILD_RESULT="Building Android App is done"
 RUN rm -rf ./www ./platforms ./plugins && \
     npm run build -- --configuration=production && \
     cordova platform add android && \
-    cordova build android --release --buildConfig=build.json -- -d && \
+    cordova build android --release --buildConfig=build.json --packageType=${PACKAGE_TYPE} -- -d && \
     mkdir -p ./output/android && \
     mv ./platforms/android/* ./output/android
 
@@ -95,7 +99,7 @@ ENV BUILD_RESULT="Building Android and then iOS Apps is done"
 RUN rm -rf ./www ./platforms ./plugins && \
     npm run build -- --configuration=production && \
     cordova platform add android && \
-    cordova build android --release --buildConfig=build.json -- -d && \
+    cordova build android --release --buildConfig=build.json --packageType=${PACKAGE_TYPE} -- -d && \
     mkdir -p ./output/android && \
     mv ./platforms/android/* ./output/android
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ These files can be placed inside an Ionic project to use.
 * `app-builder.Dockerfile` — builds the heavy **toolchain base image** (Ubuntu + JDK + Android SDK + Node + Cordova/Ionic CLIs). Build it once and reuse it; that's why it is a separate image.
 * `Dockerfile` — `FROM app-builder`, copies your app in and runs `ionic cordova build`. This is the per-app build.
 * `build-mobile.sh` — convenience wrapper that builds both images and copies the artifact out.
-* `example-app/` — a stock Ionic starter you can **clone and build immediately** to test the pipeline end-to-end. It carries its **own copies** of the three files above so it is self-contained (Docker can't reach files outside its build context, so the copies are required, not accidental). The root files are the source of truth; the `example-app` copies of `Dockerfile` and `app-builder.Dockerfile` are kept byte-for-byte identical (CI enforces this). `example-app/build-mobile.sh` is intentionally slightly different (it uses `version=0.0.0` and comments out `docker push`).
+* `example-app/` — a stock Ionic starter you can **clone and build immediately** to test the pipeline end-to-end. It carries its **own copies** of the three files above so it is self-contained (Docker can't reach files outside its build context, so the copies are required, not accidental). The root files are the source of truth; the `example-app` copies of `Dockerfile` and `app-builder.Dockerfile` are kept byte-for-byte identical (CI enforces this). `example-app/build-mobile.sh` is intentionally slightly different (it uses `version=0.0.0` and a self-contained header comment).
 
 To try it out right away:
 ```shell

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Arguments:
 * `ENV_NAME`: `prod` or `dev`, depending on what your environment files are called inside the `environments` folder.
 * `PLATFORM`: `ios` or `android`, or both using `all`.
 * `VERSION`: optional override for the version specified inside `config.xml`. See `Dockerfile` and uncomment the line that sets it.
+* `PACKAGE_TYPE`: Android artifact type — `bundle` (`.aab` for Google Play, default) or `apk` (installable on a device). Overrides `packageType` in `build.json`.
 
 **Finally**, to get the build out of that image:
 For the Android build:
@@ -79,6 +80,32 @@ cd ./build-output/ios && pod repo update && pod install
 ```
 
 There is a `build-mobile.sh` file if you want to run all these steps from a shell (you can comment out the first part later).
+
+## Verifying and using the Android build
+The Android build is copied to `build-output/android`. By default it produces a **signed Android App Bundle** (the file you upload to the Google Play Console):
+```
+build-output/android/app/build/outputs/bundle/release/app-release.aab
+```
+The `intermediary-bundle.aab` under `.../intermediates/` is a Gradle scratch file — ignore it.
+
+Verify the artifact is signed:
+```shell
+jarsigner -verify build-output/android/app/build/outputs/bundle/release/app-release.aab
+# -> "jar verified."
+```
+
+An `.aab` cannot be installed on a device directly. To get an **installable APK** (e.g. for sideload testing), build with `PACKAGE_TYPE=apk`:
+```shell
+PACKAGE_TYPE=apk ./build-mobile.sh android
+```
+The APK then lands under `build-output/android/app/build/outputs/apk/release/`. Alternatively, generate APKs from an existing bundle with [bundletool](https://developer.android.com/tools/bundletool):
+```shell
+bundletool build-apks --mode=universal \
+  --bundle=app-release.aab --output=app.apks \
+  --ks=keys/android.jks --ks-key-alias=alias_name
+```
+
+> ⚠️ **Signing key:** the demo signs with the committed `keys/android.jks` (passwords `Changeit` in `build.json`). For a real app, generate your **own** keystore, keep it out of source control, and supply the passwords via secrets/environment — an app signed with the demo key can never be updated on Play by you.
 
 ## Continuous integration
 `.github/workflows/build.yml` runs on push/PR and:

--- a/build-mobile.sh
+++ b/build-mobile.sh
@@ -1,70 +1,109 @@
 #!/bin/bash
+#
+# Build the Ionic/Cordova app inside Docker and copy the artifacts to ./build-output.
+#
+# Run this from the root of your Ionic project (the folder that contains package.json).
+# The repo root is only a template; to try the pipeline use: cd example-app && ./build-mobile.sh
+#
+# Usage:
+#   ./build-mobile.sh [android|ios|all]
+# With no argument an interactive menu is shown.
+#
+# Configurable via environment, e.g.:
+#   ENV_NAME=dev PACKAGE_ID=com.acme.app PACKAGE_MANAGER=yarn ./build-mobile.sh android
 
-set -e
+set -euo pipefail
 
-docker build . -f ./app-builder.Dockerfile -t app-builder
-docker push app-builder
+# --- Colors (fall back to empty strings when output is not a terminal) --------
+if [ -t 1 ]; then
+  COLOR_NC=$'\033[0m'
+  COLOR_GREEN=$'\033[0;32m'
+  COLOR_LIGHT_RED=$'\033[1;31m'
+  COLOR_LIGHT_CYAN=$'\033[1;36m'
+  COLOR_LIGHT_PURPLE=$'\033[1;35m'
+else
+  COLOR_NC='' COLOR_GREEN='' COLOR_LIGHT_RED='' COLOR_LIGHT_CYAN='' COLOR_LIGHT_PURPLE=''
+fi
 
-version="0.0.1"
+# --- Sanity check: must run from an Ionic project root ------------------------
+if [ ! -f package.json ]; then
+  printf "%bERROR:%b no package.json found in %s\n" "$COLOR_LIGHT_RED" "$COLOR_NC" "$(pwd)" >&2
+  printf "Run this from the root of your Ionic project (try: cd example-app && ./build-mobile.sh)\n" >&2
+  exit 1
+fi
+
+# --- Configuration (override any of these via the environment) ---------------
+version="${VERSION:-0.0.1}"
+ENV_NAME="${ENV_NAME:-prod}"
+PACKAGE_ID="${PACKAGE_ID:-com.example.app}"
+PACKAGE_MANAGER="${PACKAGE_MANAGER:-npm}"
 platform="all"
-ENV_NAME="prod"
-PACKAGE_ID="com.example.app"
 
-PS3="Select platform to build: "
-plt_options=("Android" "iOS" "All")
-invalid_opt="\n${COLOR_LIGHT_RED}Invalid option. Try another one.${COLOR_NC}\n"
+# --- Build the toolchain base image ------------------------------------------
+# This image is heavy but cached; you can comment this line out after the first
+# successful build to save time.
+docker build . -f ./app-builder.Dockerfile \
+  --build-arg PACKAGE_MANAGER="${PACKAGE_MANAGER}" \
+  -t app-builder
+# Only needed if you distribute the builder image to a registry — and then you
+# must tag it with your registry host, e.g. docker push registry.example.com/app-builder
+#docker push app-builder
 
-select opt in "${plt_options[@]}" "Quit"; do
-  case "$REPLY" in
-  1)
-    # shellcheck disable=SC2059
-    printf "\n${COLOR_LIGHT_CYAN}You picked to build [${COLOR_GREEN}${opt}${COLOR_LIGHT_CYAN}] platform app ${COLOR_NC}\n\n"
-    platform="android"
-    break
+# --- Platform selection ------------------------------------------------------
+case "${1:-}" in
+  android | ios | all)
+    platform="$1"
+    printf "%bBuilding [%b%s%b] platform app%b\n\n" \
+      "$COLOR_LIGHT_CYAN" "$COLOR_GREEN" "$platform" "$COLOR_LIGHT_CYAN" "$COLOR_NC"
     ;;
-  2)
-    # shellcheck disable=SC2059
-    printf "\n${COLOR_LIGHT_CYAN}You picked to build [${COLOR_LIGHT_PURPLE}${opt}${COLOR_LIGHT_CYAN}] platform app ${COLOR_NC}\n\n"
-    platform="ios"
-    break
-    ;;
-  3)
-    # shellcheck disable=SC2059
-    printf "\n${COLOR_LIGHT_CYAN}You picked to build [${COLOR_LIGHT_PURPLE}${opt}${COLOR_LIGHT_CYAN}] platforms apps ${COLOR_NC}\n\n"
-    platform="all"
-    break
-    ;;
-  $((${#plt_options[@]} + 1)))
-    printf "Quitting execution"
-    exit
+  "")
+    PS3="Select platform to build: "
+    select opt in "Android" "iOS" "All" "Quit"; do
+      case "$REPLY" in
+        1) platform="android"; break ;;
+        2) platform="ios";     break ;;
+        3) platform="all";     break ;;
+        4) printf "Quitting execution\n"; exit 0 ;;
+        *) printf "%bInvalid option. Try another one.%b\n" "$COLOR_LIGHT_RED" "$COLOR_NC" ;;
+      esac
+    done
     ;;
   *)
-    # shellcheck disable=SC2059
-    printf "${invalid_opt}"
-    continue
+    printf "%bUnknown platform '%s'.%b Use: android | ios | all\n" \
+      "$COLOR_LIGHT_RED" "$1" "$COLOR_NC" >&2
+    exit 1
     ;;
-  esac
-done
+esac
 
 cur_dir=$(pwd)
+mkdir -p "$cur_dir/build-output"
 
+# --- Build the app image -----------------------------------------------------
 docker build . \
   --build-arg ENV_NAME="${ENV_NAME}" \
   --build-arg PACKAGE_ID="${PACKAGE_ID}" \
-  --build-arg PLATFORM=${platform} \
+  --build-arg PACKAGE_MANAGER="${PACKAGE_MANAGER}" \
+  --build-arg PLATFORM="${platform}" \
   --build-arg VERSION="${version}" \
   -f ./Dockerfile \
   -t app-build
 
-if [[ "$platform" == "android" || "$platform" == "all" ]]
-then
+# --- Copy the artifacts out of the image -------------------------------------
+if [ "$platform" = "android" ] || [ "$platform" = "all" ]; then
   echo "Copying generated Android build to build-output/android"
-  docker run --user root:root --privileged=true -v "$cur_dir"/build-output:/app/mount:Z --rm --entrypoint cp app-build -r ./output/android /app/mount
+  docker run --user root:root -v "$cur_dir"/build-output:/app/mount:Z --rm \
+    --entrypoint cp app-build -r ./output/android /app/mount
 fi
 
-if [[ "$platform" == "ios" || "$platform" == "all" ]]
-then
+if [ "$platform" = "ios" ] || [ "$platform" = "all" ]; then
   echo "Copying generated iOS build to build-output/ios"
-  docker run --user root:root --privileged=true -v "$cur_dir"/build-output:/app/mount:Z --rm --entrypoint cp app-build -r ./output/ios /app/mount
-  cd "$cur_dir"/build-output/ios && pod repo update && pod install
+  docker run --user root:root -v "$cur_dir"/build-output:/app/mount:Z --rm \
+    --entrypoint cp app-build -r ./output/ios /app/mount
+  # iOS can only be *prepared* on Linux; finish the build on macOS. CocoaPods is
+  # only available there, so skip 'pod install' cleanly when it's absent.
+  if command -v pod >/dev/null 2>&1; then
+    cd "$cur_dir"/build-output/ios && pod repo update && pod install
+  else
+    echo "Skipping 'pod install' (CocoaPods not found — run it on macOS)."
+  fi
 fi

--- a/build-mobile.sh
+++ b/build-mobile.sh
@@ -11,6 +11,7 @@
 #
 # Configurable via environment, e.g.:
 #   ENV_NAME=dev PACKAGE_ID=com.acme.app PACKAGE_MANAGER=yarn ./build-mobile.sh android
+#   PACKAGE_TYPE=apk ./build-mobile.sh android   # installable .apk instead of a Play .aab
 
 set -euo pipefail
 
@@ -37,6 +38,7 @@ version="${VERSION:-0.0.1}"
 ENV_NAME="${ENV_NAME:-prod}"
 PACKAGE_ID="${PACKAGE_ID:-com.example.app}"
 PACKAGE_MANAGER="${PACKAGE_MANAGER:-npm}"
+PACKAGE_TYPE="${PACKAGE_TYPE:-bundle}"   # Android: "bundle" (.aab) or "apk"
 platform="all"
 
 # --- Build the toolchain base image ------------------------------------------
@@ -83,6 +85,7 @@ docker build . \
   --build-arg ENV_NAME="${ENV_NAME}" \
   --build-arg PACKAGE_ID="${PACKAGE_ID}" \
   --build-arg PACKAGE_MANAGER="${PACKAGE_MANAGER}" \
+  --build-arg PACKAGE_TYPE="${PACKAGE_TYPE}" \
   --build-arg PLATFORM="${platform}" \
   --build-arg VERSION="${version}" \
   -f ./Dockerfile \

--- a/build-mobile.sh
+++ b/build-mobile.sh
@@ -41,6 +41,25 @@ PACKAGE_MANAGER="${PACKAGE_MANAGER:-npm}"
 PACKAGE_TYPE="${PACKAGE_TYPE:-bundle}"   # Android: "bundle" (.aab) or "apk"
 platform="all"
 
+# Validate the values that get forwarded straight into the build (fail fast with a
+# clear message instead of a cryptic error deep inside the Docker build).
+case "$PACKAGE_TYPE" in
+  bundle | apk) ;;
+  *)
+    printf "%bInvalid PACKAGE_TYPE '%s'.%b Use: bundle | apk\n" \
+      "$COLOR_LIGHT_RED" "$PACKAGE_TYPE" "$COLOR_NC" >&2
+    exit 1
+    ;;
+esac
+case "$PACKAGE_MANAGER" in
+  npm | yarn | pnpm) ;;
+  *)
+    printf "%bInvalid PACKAGE_MANAGER '%s'.%b Use: npm | yarn | pnpm\n" \
+      "$COLOR_LIGHT_RED" "$PACKAGE_MANAGER" "$COLOR_NC" >&2
+    exit 1
+    ;;
+esac
+
 # --- Build the toolchain base image ------------------------------------------
 # This image is heavy but cached; you can comment this line out after the first
 # successful build to save time.

--- a/example-app/Dockerfile
+++ b/example-app/Dockerfile
@@ -5,12 +5,16 @@ ARG USER
 ARG ENV_NAME
 ARG PACKAGE_ID
 ARG VERSION
+ARG PACKAGE_TYPE
 
 # If arguments not specified then set a value
 ENV USER=${USER:-ionic}
 ENV ENV_NAME=${ENV_NAME:-dev}
 ENV PACKAGE_ID=${PACKAGE_ID:-"com.example.com"}
 ENV VERSION=${VERSION:-"MISSING"}
+# Android artifact type: "bundle" (.aab for Google Play) or "apk" (installable on a device).
+# Overrides the packageType in build.json so it can be chosen per build.
+ENV PACKAGE_TYPE=${PACKAGE_TYPE:-bundle}
 
 RUN echo "------------------------------------------"&& \
     echo "| BUILDING MOBILE APPLICATION             "&& \
@@ -72,7 +76,7 @@ ENV BUILD_RESULT="Building Android App is done"
 RUN rm -rf ./www ./platforms ./plugins && \
     npm run build -- --configuration=production && \
     cordova platform add android && \
-    cordova build android --release --buildConfig=build.json -- -d && \
+    cordova build android --release --buildConfig=build.json --packageType=${PACKAGE_TYPE} -- -d && \
     mkdir -p ./output/android && \
     mv ./platforms/android/* ./output/android
 
@@ -95,7 +99,7 @@ ENV BUILD_RESULT="Building Android and then iOS Apps is done"
 RUN rm -rf ./www ./platforms ./plugins && \
     npm run build -- --configuration=production && \
     cordova platform add android && \
-    cordova build android --release --buildConfig=build.json -- -d && \
+    cordova build android --release --buildConfig=build.json --packageType=${PACKAGE_TYPE} -- -d && \
     mkdir -p ./output/android && \
     mv ./platforms/android/* ./output/android
 

--- a/example-app/build-mobile.sh
+++ b/example-app/build-mobile.sh
@@ -11,6 +11,7 @@
 #
 # Configurable via environment, e.g.:
 #   ENV_NAME=dev PACKAGE_ID=com.acme.app PACKAGE_MANAGER=yarn ./build-mobile.sh android
+#   PACKAGE_TYPE=apk ./build-mobile.sh android   # installable .apk instead of a Play .aab
 
 set -euo pipefail
 
@@ -37,6 +38,7 @@ version="${VERSION:-0.0.0}"
 ENV_NAME="${ENV_NAME:-prod}"
 PACKAGE_ID="${PACKAGE_ID:-com.example.app}"
 PACKAGE_MANAGER="${PACKAGE_MANAGER:-npm}"
+PACKAGE_TYPE="${PACKAGE_TYPE:-bundle}"   # Android: "bundle" (.aab) or "apk"
 platform="all"
 
 # --- Build the toolchain base image ------------------------------------------
@@ -83,6 +85,7 @@ docker build . \
   --build-arg ENV_NAME="${ENV_NAME}" \
   --build-arg PACKAGE_ID="${PACKAGE_ID}" \
   --build-arg PACKAGE_MANAGER="${PACKAGE_MANAGER}" \
+  --build-arg PACKAGE_TYPE="${PACKAGE_TYPE}" \
   --build-arg PLATFORM="${platform}" \
   --build-arg VERSION="${version}" \
   -f ./Dockerfile \

--- a/example-app/build-mobile.sh
+++ b/example-app/build-mobile.sh
@@ -1,70 +1,109 @@
 #!/bin/bash
+#
+# Build the Ionic/Cordova app inside Docker and copy the artifacts to ./build-output.
+#
+# Run this from the root of your Ionic project (the folder that contains package.json).
+# This example-app is self-contained, so you can run it straight from here.
+#
+# Usage:
+#   ./build-mobile.sh [android|ios|all]
+# With no argument an interactive menu is shown.
+#
+# Configurable via environment, e.g.:
+#   ENV_NAME=dev PACKAGE_ID=com.acme.app PACKAGE_MANAGER=yarn ./build-mobile.sh android
 
-set -e
+set -euo pipefail
 
-docker build . -f ./app-builder.Dockerfile -t app-builder
+# --- Colors (fall back to empty strings when output is not a terminal) --------
+if [ -t 1 ]; then
+  COLOR_NC=$'\033[0m'
+  COLOR_GREEN=$'\033[0;32m'
+  COLOR_LIGHT_RED=$'\033[1;31m'
+  COLOR_LIGHT_CYAN=$'\033[1;36m'
+  COLOR_LIGHT_PURPLE=$'\033[1;35m'
+else
+  COLOR_NC='' COLOR_GREEN='' COLOR_LIGHT_RED='' COLOR_LIGHT_CYAN='' COLOR_LIGHT_PURPLE=''
+fi
+
+# --- Sanity check: must run from an Ionic project root ------------------------
+if [ ! -f package.json ]; then
+  printf "%bERROR:%b no package.json found in %s\n" "$COLOR_LIGHT_RED" "$COLOR_NC" "$(pwd)" >&2
+  printf "Run this from the root of your Ionic project (the folder containing package.json)\n" >&2
+  exit 1
+fi
+
+# --- Configuration (override any of these via the environment) ---------------
+version="${VERSION:-0.0.0}"
+ENV_NAME="${ENV_NAME:-prod}"
+PACKAGE_ID="${PACKAGE_ID:-com.example.app}"
+PACKAGE_MANAGER="${PACKAGE_MANAGER:-npm}"
+platform="all"
+
+# --- Build the toolchain base image ------------------------------------------
+# This image is heavy but cached; you can comment this line out after the first
+# successful build to save time.
+docker build . -f ./app-builder.Dockerfile \
+  --build-arg PACKAGE_MANAGER="${PACKAGE_MANAGER}" \
+  -t app-builder
+# Only needed if you distribute the builder image to a registry — and then you
+# must tag it with your registry host, e.g. docker push registry.example.com/app-builder
 #docker push app-builder
 
-version="0.0.0"
-platform="all"
-ENV_NAME="prod"
-PACKAGE_ID="com.example.app"
-
-PS3="Select platform to build: "
-plt_options=("Android" "iOS" "All")
-invalid_opt="\n${COLOR_LIGHT_RED}Invalid option. Try another one.${COLOR_NC}\n"
-
-select opt in "${plt_options[@]}" "Quit"; do
-  case "$REPLY" in
-  1)
-    # shellcheck disable=SC2059
-    printf "\n${COLOR_LIGHT_CYAN}You picked to build [${COLOR_GREEN}${opt}${COLOR_LIGHT_CYAN}] platform app ${COLOR_NC}\n\n"
-    platform="android"
-    break
+# --- Platform selection ------------------------------------------------------
+case "${1:-}" in
+  android | ios | all)
+    platform="$1"
+    printf "%bBuilding [%b%s%b] platform app%b\n\n" \
+      "$COLOR_LIGHT_CYAN" "$COLOR_GREEN" "$platform" "$COLOR_LIGHT_CYAN" "$COLOR_NC"
     ;;
-  2)
-    # shellcheck disable=SC2059
-    printf "\n${COLOR_LIGHT_CYAN}You picked to build [${COLOR_LIGHT_PURPLE}${opt}${COLOR_LIGHT_CYAN}] platform app ${COLOR_NC}\n\n"
-    platform="ios"
-    break
-    ;;
-  3)
-    # shellcheck disable=SC2059
-    printf "\n${COLOR_LIGHT_CYAN}You picked to build [${COLOR_LIGHT_PURPLE}${opt}${COLOR_LIGHT_CYAN}] platforms apps ${COLOR_NC}\n\n"
-    platform="all"
-    break
-    ;;
-  $((${#plt_options[@]} + 1)))
-    printf "Quitting execution"
-    exit
+  "")
+    PS3="Select platform to build: "
+    select opt in "Android" "iOS" "All" "Quit"; do
+      case "$REPLY" in
+        1) platform="android"; break ;;
+        2) platform="ios";     break ;;
+        3) platform="all";     break ;;
+        4) printf "Quitting execution\n"; exit 0 ;;
+        *) printf "%bInvalid option. Try another one.%b\n" "$COLOR_LIGHT_RED" "$COLOR_NC" ;;
+      esac
+    done
     ;;
   *)
-    # shellcheck disable=SC2059
-    printf "${invalid_opt}"
-    continue
+    printf "%bUnknown platform '%s'.%b Use: android | ios | all\n" \
+      "$COLOR_LIGHT_RED" "$1" "$COLOR_NC" >&2
+    exit 1
     ;;
-  esac
-done
+esac
 
 cur_dir=$(pwd)
+mkdir -p "$cur_dir/build-output"
 
+# --- Build the app image -----------------------------------------------------
 docker build . \
   --build-arg ENV_NAME="${ENV_NAME}" \
   --build-arg PACKAGE_ID="${PACKAGE_ID}" \
-  --build-arg PLATFORM=${platform} \
+  --build-arg PACKAGE_MANAGER="${PACKAGE_MANAGER}" \
+  --build-arg PLATFORM="${platform}" \
   --build-arg VERSION="${version}" \
   -f ./Dockerfile \
   -t app-build
 
-if [[ "$platform" == "android" || "$platform" == "all" ]]
-then
+# --- Copy the artifacts out of the image -------------------------------------
+if [ "$platform" = "android" ] || [ "$platform" = "all" ]; then
   echo "Copying generated Android build to build-output/android"
-  docker run --user root:root --privileged=true -v "$cur_dir"/build-output:/app/mount:Z --rm --entrypoint cp app-build -r ./output/android /app/mount
+  docker run --user root:root -v "$cur_dir"/build-output:/app/mount:Z --rm \
+    --entrypoint cp app-build -r ./output/android /app/mount
 fi
 
-if [[ "$platform" == "ios" || "$platform" == "all" ]]
-then
+if [ "$platform" = "ios" ] || [ "$platform" = "all" ]; then
   echo "Copying generated iOS build to build-output/ios"
-  docker run --user root:root --privileged=true -v "$cur_dir"/build-output:/app/mount:Z --rm --entrypoint cp app-build -r ./output/ios /app/mount
-  cd "$cur_dir"/build-output/ios && pod repo update && pod install
+  docker run --user root:root -v "$cur_dir"/build-output:/app/mount:Z --rm \
+    --entrypoint cp app-build -r ./output/ios /app/mount
+  # iOS can only be *prepared* on Linux; finish the build on macOS. CocoaPods is
+  # only available there, so skip 'pod install' cleanly when it's absent.
+  if command -v pod >/dev/null 2>&1; then
+    cd "$cur_dir"/build-output/ios && pod repo update && pod install
+  else
+    echo "Skipping 'pod install' (CocoaPods not found — run it on macOS)."
+  fi
 fi

--- a/example-app/build-mobile.sh
+++ b/example-app/build-mobile.sh
@@ -41,6 +41,25 @@ PACKAGE_MANAGER="${PACKAGE_MANAGER:-npm}"
 PACKAGE_TYPE="${PACKAGE_TYPE:-bundle}"   # Android: "bundle" (.aab) or "apk"
 platform="all"
 
+# Validate the values that get forwarded straight into the build (fail fast with a
+# clear message instead of a cryptic error deep inside the Docker build).
+case "$PACKAGE_TYPE" in
+  bundle | apk) ;;
+  *)
+    printf "%bInvalid PACKAGE_TYPE '%s'.%b Use: bundle | apk\n" \
+      "$COLOR_LIGHT_RED" "$PACKAGE_TYPE" "$COLOR_NC" >&2
+    exit 1
+    ;;
+esac
+case "$PACKAGE_MANAGER" in
+  npm | yarn | pnpm) ;;
+  *)
+    printf "%bInvalid PACKAGE_MANAGER '%s'.%b Use: npm | yarn | pnpm\n" \
+      "$COLOR_LIGHT_RED" "$PACKAGE_MANAGER" "$COLOR_NC" >&2
+    exit 1
+    ;;
+esac
+
 # --- Build the toolchain base image ------------------------------------------
 # This image is heavy but cached; you can comment this line out after the first
 # successful build to save time.


### PR DESCRIPTION
Cleans up both `build-mobile.sh` files (root template + `example-app` copy), which are several years old, and adds a way to choose the Android artifact type.

## Script hardening

- **Remove the broken `docker push app-builder`.** A bare image name resolves to the reserved `docker.io/library/` namespace, so the push always failed with `denied: requested access to the resource is denied`. With `set -e` that aborted the whole build before the app was built. Now commented, with a note explaining it's only for distributing the builder image to a real registry (and must be tagged with the registry host).
- **Argument support:** `./build-mobile.sh [android|ios|all]` runs non-interactively; no argument still shows the interactive menu; an unknown value errors clearly.
- **`package.json` guard** — clear "run this from your project root" message instead of the cryptic Docker `"/package.json": not found` you get when running from a non-project directory.
- **Define `COLOR_*` variables** that were referenced but never set (so colored output actually worked), made TTY-aware so piped logs stay clean.
- **Drop `--privileged=true`** from the artifact-copy container — a plain `cp` to a bind mount doesn't need extra capabilities.
- **Guard `pod install`** behind `command -v pod` so the iOS path no longer fails on Linux (CocoaPods is macOS-only).
- **Hardening:** `set -euo pipefail`, pre-create `build-output/`, and forward `PACKAGE_MANAGER` to both image builds (it was wired into the Dockerfiles in #47 but the script never passed it).

## New: choose Android `.aab` vs `.apk`

By default the build produces a signed Android App Bundle (`.aab`) for Google Play. Added a `PACKAGE_TYPE` build-arg (default `bundle`) so an installable `.apk` can be produced without editing `build.json`:

```bash
PACKAGE_TYPE=apk ./build-mobile.sh android
```

- **Dockerfile** (root + identical `example-app` copy): new `ARG`/`ENV PACKAGE_TYPE`, passed to `cordova build android --packageType=...`, overriding the value in `build.json`.
- **build-mobile.sh** (both copies): forward `PACKAGE_TYPE` as a `--build-arg`.

## README

- Both scripts now comment out `docker push`, so the description of how they differ is updated accordingly.
- Document the `PACKAGE_TYPE` argument.
- New **"Verifying and using the Android build"** section: where the `.aab` lands, how to verify the signature with `jarsigner`, how to get an APK (`PACKAGE_TYPE=apk` or `bundletool`), and a warning that the committed demo keystore must be replaced for real apps.

## Notes / verification

- Both scripts pass `bash -n`.
- The two Dockerfiles remain byte-for-byte identical (CI parity gate).
- The scripts differ only by the documented bits (`version` and a self-contained header comment in `example-app`).

## Test

```bash
cd example-app
./build-mobile.sh android                    # signed .aab
PACKAGE_TYPE=apk ./build-mobile.sh android    # installable .apk
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)