### PR TITLE
Drop Corepack from the toolchain image; install only the selected package manager

### DIFF
--- a/app-builder.Dockerfile
+++ b/app-builder.Dockerfile
@@ -136,24 +136,25 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
     node --version && \
     npm --version
 
-# Yarn and pnpm are provided through Corepack (bundled with Node), so all three package
-# managers (npm + yarn + pnpm) are available; pick one per build via PACKAGE_MANAGER.
-# COREPACK_HOME is a shared, world-writable cache so the non-root build user can use (and
-# resolve project-pinned versions of) the prepared package managers (Corepack's default
-# cache otherwise lives in root's home, unreadable to the build user).
+# Yarn and pnpm are installed on demand with npm (which always ships with Node). We avoid
+# Corepack on purpose: it is being unbundled from Node (25+), so relying on it would break
+# the moment NODE_VERSION moves forward. Only the SELECTED manager is installed — npm builds
+# (the default) add nothing extra, keeping the image smaller. Pick one per build via
+# PACKAGE_MANAGER. This RUN executes as root, so the global install lands on the shared PATH
+# and stays usable by the non-root build user created later.
 ARG YARN_VERSION
 ENV YARN_VERSION=${YARN_VERSION:-stable}
 
 ARG PNPM_VERSION
 ENV PNPM_VERSION=${PNPM_VERSION:-latest}
 
-ENV COREPACK_HOME=/opt/corepack
-
-RUN corepack enable && \
-    corepack prepare yarn@${YARN_VERSION} pnpm@${PNPM_VERSION} --activate && \
-    chmod -R a+rwX ${COREPACK_HOME} && \
-    yarn --version && \
-    pnpm --version
+RUN if [ "${PACKAGE_MANAGER}" = "pnpm" ]; then \
+      npm install -g pnpm@${PNPM_VERSION} && pnpm --version; \
+    elif [ "${PACKAGE_MANAGER}" = "yarn" ]; then \
+      npm install -g yarn@${YARN_VERSION} && yarn --version; \
+    else \
+      echo "Using npm bundled with Node; no extra package manager installed."; \
+    fi
 
 # -----------------------------------------------------------------------------
 # Install Ruby + CocoaPods (used when preparing the iOS project)

--- a/example-app/app-builder.Dockerfile
+++ b/example-app/app-builder.Dockerfile
@@ -136,24 +136,25 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
     node --version && \
     npm --version
 
-# Yarn and pnpm are provided through Corepack (bundled with Node), so all three package
-# managers (npm + yarn + pnpm) are available; pick one per build via PACKAGE_MANAGER.
-# COREPACK_HOME is a shared, world-writable cache so the non-root build user can use (and
-# resolve project-pinned versions of) the prepared package managers (Corepack's default
-# cache otherwise lives in root's home, unreadable to the build user).
+# Yarn and pnpm are installed on demand with npm (which always ships with Node). We avoid
+# Corepack on purpose: it is being unbundled from Node (25+), so relying on it would break
+# the moment NODE_VERSION moves forward. Only the SELECTED manager is installed — npm builds
+# (the default) add nothing extra, keeping the image smaller. Pick one per build via
+# PACKAGE_MANAGER. This RUN executes as root, so the global install lands on the shared PATH
+# and stays usable by the non-root build user created later.
 ARG YARN_VERSION
 ENV YARN_VERSION=${YARN_VERSION:-stable}
 
 ARG PNPM_VERSION
 ENV PNPM_VERSION=${PNPM_VERSION:-latest}
 
-ENV COREPACK_HOME=/opt/corepack
-
-RUN corepack enable && \
-    corepack prepare yarn@${YARN_VERSION} pnpm@${PNPM_VERSION} --activate && \
-    chmod -R a+rwX ${COREPACK_HOME} && \
-    yarn --version && \
-    pnpm --version
+RUN if [ "${PACKAGE_MANAGER}" = "pnpm" ]; then \
+      npm install -g pnpm@${PNPM_VERSION} && pnpm --version; \
+    elif [ "${PACKAGE_MANAGER}" = "yarn" ]; then \
+      npm install -g yarn@${YARN_VERSION} && yarn --version; \
+    else \
+      echo "Using npm bundled with Node; no extra package manager installed."; \
+    fi
 
 # -----------------------------------------------------------------------------
 # Install Ruby + CocoaPods (used when preparing the iOS project)


### PR DESCRIPTION
## Why

Corepack is being unbundled from Node (25+). The toolchain image currently provisions yarn/pnpm via `corepack enable && corepack prepare …`, which will break the moment `NODE_VERSION` moves forward. It also eagerly installs **both** yarn and pnpm even for npm builds.

## What

- Replace the Corepack block (and `COREPACK_HOME`) in `app-builder.Dockerfile` with a conditional `npm install -g` of **only the manager selected** via `PACKAGE_MANAGER`. npm ships with Node, so the default (npm) image installs nothing extra and is smaller.
- Mirrored into `example-app/app-builder.Dockerfile` so the **drift-guard** stays green.
- No app-code or `package.json` changes; npm remains this repo's default.

## Verification

Built `app-builder` locally with `--build-arg PACKAGE_MANAGER=pnpm`:

```
node=v24.18.0
pnpm=11.9.0
PM=pnpm
yarn=absent-expected
```

pnpm present, yarn correctly absent, no Corepack needed. CI re-validates the toolchain image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)