### PR TITLE
docs: link the Capacitor sibling repo; widen Corepack comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ So this is a project that should help you produce an Android project and build, 
 
 These files can be placed inside an Ionic project to use.
 
+> Prefer Capacitor? See the sibling project [ionic-capacitor-docker](https://github.com/capellasolutions/ionic-capacitor-docker) — the same Dockerized pipeline built around Capacitor (and it defaults to pnpm instead of npm).
+
 ## Repository layout
 * `app-builder.Dockerfile` — builds the heavy **toolchain base image** (Ubuntu + JDK + Android SDK + Node + Cordova/Ionic CLIs). Build it once and reuse it; that's why it is a separate image.
 * `Dockerfile` — `FROM app-builder`, copies your app in, builds the Angular web app and runs `cordova build`. This is the per-app build.

--- a/app-builder.Dockerfile
+++ b/app-builder.Dockerfile
@@ -136,12 +136,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
     node --version && \
     npm --version
 
-# Yarn and pnpm are installed on demand with npm (which always ships with Node). We avoid
-# Corepack on purpose: it is being unbundled from Node (25+), so relying on it would break
-# the moment NODE_VERSION moves forward. Only the SELECTED manager is installed — npm builds
-# (the default) add nothing extra, keeping the image smaller. Pick one per build via
-# PACKAGE_MANAGER. This RUN executes as root, so the global install lands on the shared PATH
-# and stays usable by the non-root build user created later.
+# Yarn and pnpm are installed on demand with npm (which always ships with Node). We avoid Corepack on purpose: it is
+# being unbundled from Node (25+), so relying on it would break the moment NODE_VERSION moves forward. Only the SELECTED
+# manager is installed — npm builds (the default) add nothing extra, keeping the image smaller. Pick one per build via
+# PACKAGE_MANAGER. This RUN executes as root, so the global install lands on the shared PATH and stays usable by the
+# non-root build user created later.
 ARG YARN_VERSION
 ENV YARN_VERSION=${YARN_VERSION:-stable}
 

--- a/example-app/app-builder.Dockerfile
+++ b/example-app/app-builder.Dockerfile
@@ -136,12 +136,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
     node --version && \
     npm --version
 
-# Yarn and pnpm are installed on demand with npm (which always ships with Node). We avoid
-# Corepack on purpose: it is being unbundled from Node (25+), so relying on it would break
-# the moment NODE_VERSION moves forward. Only the SELECTED manager is installed — npm builds
-# (the default) add nothing extra, keeping the image smaller. Pick one per build via
-# PACKAGE_MANAGER. This RUN executes as root, so the global install lands on the shared PATH
-# and stays usable by the non-root build user created later.
+# Yarn and pnpm are installed on demand with npm (which always ships with Node). We avoid Corepack on purpose: it is
+# being unbundled from Node (25+), so relying on it would break the moment NODE_VERSION moves forward. Only the SELECTED
+# manager is installed — npm builds (the default) add nothing extra, keeping the image smaller. Pick one per build via
+# PACKAGE_MANAGER. This RUN executes as root, so the global install lands on the shared PATH and stays usable by the
+# non-root build user created later.
 ARG YARN_VERSION
 ENV YARN_VERSION=${YARN_VERSION:-stable}
 


### PR DESCRIPTION
## What
- Add a pointer to the **Capacitor sibling** repo ([ionic-capacitor-docker](https://github.com/capellasolutions/ionic-capacitor-docker)) in the README — the reverse of the link that repo already carries back to this one.
- Reflow the Corepack-removal comment in `app-builder.Dockerfile` to ~120 cols so the paragraph stays together (easier to read). Mirrored into the `example-app` copy so the drift-guard stays green.

Docs/comment only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)