### PR TITLE
Pin *.md / *.yml / *.yaml to LF in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,12 @@ Dockerfile.*    text eol=lf
 .editorconfig text eol=lf
 *.conf       text eol=lf
 
+# Docs and structured config — keep LF so Windows checkouts don't add CRLF. This silences the noisy
+# "LF will be replaced by CRLF the next time Git touches it" warning and keeps diffs clean across platforms.
+*.md   text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+
 # --- Force CRLF for Windows-only scripts ---
 *.bat text eol=crlf
 *.cmd text eol=crlf


### PR DESCRIPTION
`.gitattributes` pins shell scripts, Dockerfiles, and a few dotfiles to LF, but docs and structured config were left to `* text=auto`. On Windows checkouts that produces the recurring warning:

```
warning: in the working copy of ''README.md'', LF will be replaced by CRLF the next time Git touches it
```

Pin `*.md`, `*.yml`, and `*.yaml` to LF so diffs stay clean across platforms. No file content changes — this only affects line-ending normalization going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)